### PR TITLE
代码优化

### DIFF
--- a/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherBSERecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherBSERecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.ddf;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndian;
 
@@ -29,6 +31,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndian;
  * @see EscherBlipRecord
  */
 public final class EscherBSERecord extends EscherRecord {
+    @Keep
     public static final short RECORD_ID = (short) 0xF007;
     public static final String RECORD_DESCRIPTION = "MsofbtBSE";
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherBinaryTagRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherBinaryTagRecord.java
@@ -6,6 +6,8 @@
  */
 package com.cherry.lib.doc.office.fc.ddf;
 
+import androidx.annotation.Keep;
+
 /**
  * holds data of extended pagraph style(bullets and number ruler)
  * <p>
@@ -24,7 +26,7 @@ package com.cherry.lib.doc.office.fc.ddf;
  */
 public class EscherBinaryTagRecord extends EscherTextboxRecord
 {
-    //
+    @Keep
     public static final short RECORD_ID = (short)0x138B;
     
     //

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherChildAnchorRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherChildAnchorRecord.java
@@ -18,6 +18,8 @@
 
 package com.cherry.lib.doc.office.fc.ddf;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndian;
 
@@ -31,6 +33,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndian;
 public class EscherChildAnchorRecord
         extends EscherRecord
 {
+    @Keep
     public static final short RECORD_ID = (short) 0xF00F;
     public static final String RECORD_DESCRIPTION = "MsofbtChildAnchor";
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherClientAnchorRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherClientAnchorRecord.java
@@ -19,6 +19,8 @@
 package com.cherry.lib.doc.office.fc.ddf;
 
 
+import androidx.annotation.Keep;
+
 import java.io.ByteArrayOutputStream;
 
 import com.cherry.lib.doc.office.fc.util.HexDump;
@@ -36,6 +38,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndian;
 public class EscherClientAnchorRecord
         extends EscherRecord
 {
+    @Keep
     public static final short RECORD_ID = (short) 0xF010;
     public static final String RECORD_DESCRIPTION = "MsofbtClientAnchor";
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherClientDataRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherClientDataRecord.java
@@ -19,6 +19,8 @@
 package com.cherry.lib.doc.office.fc.ddf;
 
 
+import androidx.annotation.Keep;
+
 import java.io.ByteArrayOutputStream;
 
 import com.cherry.lib.doc.office.fc.util.HexDump;
@@ -33,6 +35,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndian;
 public class EscherClientDataRecord
     extends EscherRecord
 {
+    @Keep
     public static final short RECORD_ID = (short) 0xF011;
     public static final String RECORD_DESCRIPTION = "MsofbtClientData";
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherDgRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherDgRecord.java
@@ -18,6 +18,8 @@
 
 package com.cherry.lib.doc.office.fc.ddf;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndian;
 
@@ -30,6 +32,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndian;
 public class EscherDgRecord
     extends EscherRecord
 {
+    @Keep
     public static final short RECORD_ID = (short) 0xF008;
     public static final String RECORD_DESCRIPTION = "MsofbtDg";
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherDggRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherDggRecord.java
@@ -18,6 +18,8 @@
 package com.cherry.lib.doc.office.fc.ddf;
 
 
+import androidx.annotation.Keep;
+
 import java.util.*;
 
 import com.cherry.lib.doc.office.fc.util.HexDump;
@@ -28,6 +30,7 @@ import com.cherry.lib.doc.office.fc.util.RecordFormatException;
  * This record defines the drawing groups used for a particular sheet.
  */
 public final class EscherDggRecord extends EscherRecord {
+    @Keep
     public static final short RECORD_ID = (short) 0xF006;
     public static final String RECORD_DESCRIPTION = "MsofbtDgg";
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherOptRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherOptRecord.java
@@ -16,6 +16,8 @@
 ==================================================================== */
 package com.cherry.lib.doc.office.fc.ddf;
 
+import androidx.annotation.Keep;
+
 /**
  * The opt record is used to store property values for a shape. It is the key to
  * determining the attributes of a shape. Properties can be of two types: simple
@@ -25,6 +27,7 @@ package com.cherry.lib.doc.office.fc.ddf;
  * @author Glen Stampoultzis
  */
 public class EscherOptRecord extends AbstractEscherOptRecord {
+    @Keep
     public static final short RECORD_ID = (short) 0xF00B;
     public static final String RECORD_DESCRIPTION = "msofbtOPT";
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherSpRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherSpRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.ddf;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndian;
 
@@ -29,6 +31,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndian;
 public class EscherSpRecord
     extends EscherRecord
 {
+    @Keep
     public static final short RECORD_ID = (short) 0xF00A;
     public static final String RECORD_DESCRIPTION = "MsofbtSp";
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherSpgrRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherSpgrRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.ddf;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndian;
 import com.cherry.lib.doc.office.fc.util.RecordFormatException;
@@ -30,6 +32,7 @@ import com.cherry.lib.doc.office.fc.util.RecordFormatException;
 public class EscherSpgrRecord
     extends EscherRecord
 {
+    @Keep
     public static final short RECORD_ID = (short) 0xF009;
     public static final String RECORD_DESCRIPTION = "MsofbtSpgr";
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherSplitMenuColorsRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherSplitMenuColorsRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.ddf;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndian;
 import com.cherry.lib.doc.office.fc.util.RecordFormatException;
@@ -30,6 +32,7 @@ import com.cherry.lib.doc.office.fc.util.RecordFormatException;
 public class EscherSplitMenuColorsRecord
     extends EscherRecord
 {
+    @Keep
     public static final short RECORD_ID = (short) 0xF11E;
     public static final String RECORD_DESCRIPTION = "MsofbtSplitMenuColors";
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherTertiaryOptRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherTertiaryOptRecord.java
@@ -16,6 +16,8 @@
 ==================================================================== */
 package com.cherry.lib.doc.office.fc.ddf;
 
+import androidx.annotation.Keep;
+
 /**
  * "The OfficeArtTertiaryFOPT record specifies a table of OfficeArtRGFOPTE properties, as defined in section 2.3.1."
  * -- [MS-ODRAW] -- v20110608; Office Drawing Binary File Format
@@ -24,6 +26,7 @@ package com.cherry.lib.doc.office.fc.ddf;
  */
 public class EscherTertiaryOptRecord extends AbstractEscherOptRecord
 {
+    @Keep
     public static final short RECORD_ID = (short) 0xF122;
 
     public String getRecordName()

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherTextboxRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/ddf/EscherTextboxRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.ddf;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndian;
 import com.cherry.lib.doc.office.fc.util.RecordFormatException;
@@ -32,6 +34,7 @@ import com.cherry.lib.doc.office.fc.util.RecordFormatException;
  */
 public class EscherTextboxRecord extends EscherRecord
 {
+    @Keep
     public static final short RECORD_ID = (short)0xF00D;
     public static final String RECORD_DESCRIPTION = "msofbtClientTextbox";
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/dom4j/DocumentHelper.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/dom4j/DocumentHelper.java
@@ -7,6 +7,8 @@
 
 package com.cherry.lib.doc.office.fc.dom4j;
 
+import androidx.annotation.Keep;
+
 import java.io.StringReader;
 import java.util.List;
 import java.util.Map;
@@ -307,7 +309,7 @@ public final class DocumentHelper
 
         return result;
     }
-
+    @Keep
     private static String getEncoding(String text)
     {
         String result = null;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/dom4j/io/OutputFormat.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/dom4j/io/OutputFormat.java
@@ -7,6 +7,8 @@
 
 package com.cherry.lib.doc.office.fc.dom4j.io;
 
+import androidx.annotation.Keep;
+
 /**
  * <p>
  * <code>OutputFormat</code> represents the format configuration used by
@@ -168,7 +170,7 @@ public class OutputFormat implements Cloneable {
     public void setNewlines(boolean newlines) {
         this.newlines = newlines;
     }
-
+    @Keep
     public String getEncoding() {
         return encoding;
     }

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/dom4j/io/SAXContentHandler.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/dom4j/io/SAXContentHandler.java
@@ -7,6 +7,8 @@
 
 package com.cherry.lib.doc.office.fc.dom4j.io;
 
+import androidx.annotation.Keep;
+
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -939,6 +941,7 @@ public class SAXContentHandler extends DefaultHandler implements LexicalHandler,
         return doc;
     }
 
+    @Keep
     private String getEncoding()
     {
         if (locator == null)

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/dom4j/io/SAXReader.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/dom4j/io/SAXReader.java
@@ -7,6 +7,8 @@
 
 package com.cherry.lib.doc.office.fc.dom4j.io;
 
+import androidx.annotation.Keep;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -789,6 +791,7 @@ public class SAXReader
      * @return encoding used for InputSource
      * 
      */
+    @Keep
     public String getEncoding()
     {
         return encoding;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/dom4j/xpath/DefaultNamespaceContext.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/dom4j/xpath/DefaultNamespaceContext.java
@@ -7,6 +7,8 @@
 
 package com.cherry.lib.doc.office.fc.dom4j.xpath;
 
+import androidx.annotation.Keep;
+
 import java.io.Serializable;
 import java.util.Iterator;
 
@@ -35,7 +37,7 @@ public class DefaultNamespaceContext implements NamespaceContext, Serializable
     {
         this.element = element;
     }
-
+    @Keep
     public static DefaultNamespaceContext create(Object node)
     {
         Element element = null;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hpsf/PropertySetFactory.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hpsf/PropertySetFactory.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hpsf;
 
+import androidx.annotation.Keep;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -50,6 +52,7 @@ public class PropertySetFactory
      * @exception UnsupportedEncodingException if the specified codepage is not
      * supported.
      */
+    @Keep
     public static PropertySet create(final InputStream stream)
         throws NoPropertySetStreamException, MarkUnsupportedException,
                UnsupportedEncodingException, IOException

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/BinaryTagDataBlob.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/BinaryTagDataBlob.java
@@ -6,6 +6,8 @@
  */
 package com.cherry.lib.doc.office.fc.hslf.record;
 
+import androidx.annotation.Keep;
+
 /**
  * TODO: An atom record that contains the value of the name-value pair 
  * in a programmable tag.
@@ -26,6 +28,7 @@ package com.cherry.lib.doc.office.fc.hslf.record;
 public class BinaryTagDataBlob extends PositionDependentRecordContainer
 {
     private byte[] _header;
+    @Keep
     public static long RECORD_ID = 0x138B;
     
     /**

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/ClientVisualElementContainer.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/ClientVisualElementContainer.java
@@ -6,6 +6,8 @@
  */
 package com.cherry.lib.doc.office.fc.hslf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hslf.record.PositionDependentRecordContainer;
 import com.cherry.lib.doc.office.fc.hslf.record.Record;
 
@@ -28,6 +30,7 @@ import com.cherry.lib.doc.office.fc.hslf.record.Record;
 public class ClientVisualElementContainer extends PositionDependentRecordContainer
 {
     private byte[] _header;
+    @Keep
     public static long RECORD_ID = 0xF13C;
     
     /**

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/PPDrawing.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/PPDrawing.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hslf.record;
 
+import androidx.annotation.Keep;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Iterator;
@@ -273,6 +275,7 @@ public final class PPDrawing extends RecordAtom
     /**
      * Create the Escher records associated with a new PPDrawing
      */
+    @Keep
     private void create()
     {
         EscherContainerRecord dgContainer = new EscherContainerRecord();

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/SlideProgBinaryTagContainer.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/SlideProgBinaryTagContainer.java
@@ -6,6 +6,8 @@
  */
 package com.cherry.lib.doc.office.fc.hslf.record;
 
+import androidx.annotation.Keep;
+
 /**
  * TODO: 文件注释
  * <p>
@@ -25,6 +27,7 @@ package com.cherry.lib.doc.office.fc.hslf.record;
 public class SlideProgBinaryTagContainer extends PositionDependentRecordContainer
 {
     private byte[] _header;
+    @Keep
     public static long RECORD_ID = 0x138A;
     
     /**

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/SlideProgTagsContainer.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/SlideProgTagsContainer.java
@@ -6,6 +6,8 @@
  */
 package com.cherry.lib.doc.office.fc.hslf.record;
 
+import androidx.annotation.Keep;
+
 /**
  * TODO: A container record that specifies programmable tags with additional slide data.
  * <p>
@@ -25,6 +27,7 @@ package com.cherry.lib.doc.office.fc.hslf.record;
 public class SlideProgTagsContainer extends PositionDependentRecordContainer
 {
     private byte[] _header;
+    @Keep
     public static long RECORD_ID = 0x1388;
     
     /**

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/TimeAnimateBehaviorContainer.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/TimeAnimateBehaviorContainer.java
@@ -6,6 +6,8 @@
  */
 package com.cherry.lib.doc.office.fc.hslf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hslf.record.PositionDependentRecordContainer;
 import com.cherry.lib.doc.office.fc.hslf.record.Record;
 
@@ -28,6 +30,7 @@ import com.cherry.lib.doc.office.fc.hslf.record.Record;
 public class TimeAnimateBehaviorContainer extends PositionDependentRecordContainer
 {
     private byte[] _header;
+    @Keep
     public static long RECORD_ID = 0xF12B;
     
     /**

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/TimeBehaviorContainer.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/TimeBehaviorContainer.java
@@ -6,6 +6,8 @@
  */
 package com.cherry.lib.doc.office.fc.hslf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hslf.record.PositionDependentRecordContainer;
 import com.cherry.lib.doc.office.fc.hslf.record.Record;
 
@@ -28,6 +30,7 @@ import com.cherry.lib.doc.office.fc.hslf.record.Record;
 public class TimeBehaviorContainer extends PositionDependentRecordContainer
 {
     private byte[] _header;
+    @Keep
     public static long RECORD_ID = 0xF12A;
     
     /**

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/TimeColorBehaviorContainer.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/TimeColorBehaviorContainer.java
@@ -6,6 +6,8 @@
  */
 package com.cherry.lib.doc.office.fc.hslf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hslf.record.PositionDependentRecordContainer;
 import com.cherry.lib.doc.office.fc.hslf.record.Record;
 
@@ -35,6 +37,7 @@ import com.cherry.lib.doc.office.fc.hslf.record.Record;
 public class TimeColorBehaviorContainer extends PositionDependentRecordContainer
 {
     private byte[] _header;
+    @Keep
     public static long RECORD_ID = 0xF12C;
     
     //how to change the color of the object and which attributes within this field are valid

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/TimeCommandBehaviorContainer.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/TimeCommandBehaviorContainer.java
@@ -6,6 +6,8 @@
  */
 package com.cherry.lib.doc.office.fc.hslf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hslf.record.PositionDependentRecordContainer;
 import com.cherry.lib.doc.office.fc.hslf.record.Record;
 
@@ -28,6 +30,7 @@ import com.cherry.lib.doc.office.fc.hslf.record.Record;
 public class TimeCommandBehaviorContainer extends PositionDependentRecordContainer
 {
     private byte[] _header;
+    @Keep
     public static long RECORD_ID = 0xF132;
     
     /**

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/TimeEffectBehaviorContainer.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/TimeEffectBehaviorContainer.java
@@ -6,6 +6,8 @@
  */
 package com.cherry.lib.doc.office.fc.hslf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hslf.record.PositionDependentRecordContainer;
 import com.cherry.lib.doc.office.fc.hslf.record.Record;
 
@@ -31,6 +33,7 @@ import com.cherry.lib.doc.office.fc.hslf.record.Record;
 public class TimeEffectBehaviorContainer extends PositionDependentRecordContainer
 {
     private byte[] _header;
+    @Keep
     public static long RECORD_ID = 0xF12D;
     
     /**

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/TimeMotionBehaviorContainer.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/TimeMotionBehaviorContainer.java
@@ -6,6 +6,8 @@
  */
 package com.cherry.lib.doc.office.fc.hslf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hslf.record.PositionDependentRecordContainer;
 import com.cherry.lib.doc.office.fc.hslf.record.Record;
 
@@ -34,6 +36,7 @@ import com.cherry.lib.doc.office.fc.hslf.record.Record;
 public class TimeMotionBehaviorContainer extends PositionDependentRecordContainer
 {
     private byte[] _header;
+    @Keep
     public static long RECORD_ID = 0xF12E;
     
     /**

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/TimeNodeAttributeContainer.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/TimeNodeAttributeContainer.java
@@ -6,6 +6,8 @@
  */
 package com.cherry.lib.doc.office.fc.hslf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hslf.record.PositionDependentRecordContainer;
 import com.cherry.lib.doc.office.fc.hslf.record.Record;
 
@@ -28,6 +30,7 @@ import com.cherry.lib.doc.office.fc.hslf.record.Record;
 public class TimeNodeAttributeContainer extends PositionDependentRecordContainer
 {   
     private byte[] _header;
+    @Keep
     public static long RECORD_ID = 0xF13D;
     
     /**

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/TimeNodeContainer.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/TimeNodeContainer.java
@@ -6,6 +6,8 @@
  */
 package com.cherry.lib.doc.office.fc.hslf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hslf.record.PositionDependentRecordContainer;
 import com.cherry.lib.doc.office.fc.hslf.record.Record;
 
@@ -34,6 +36,7 @@ import com.cherry.lib.doc.office.fc.hslf.record.Record;
 public class TimeNodeContainer extends PositionDependentRecordContainer
 {
     private byte[] _header;
+    @Keep
     public static long RECORD_ID = 0xF144;
     
     /**

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/TimeRotationBehaviorContainer.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/TimeRotationBehaviorContainer.java
@@ -6,6 +6,8 @@
  */
 package com.cherry.lib.doc.office.fc.hslf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hslf.record.PositionDependentRecordContainer;
 import com.cherry.lib.doc.office.fc.hslf.record.Record;
 
@@ -33,6 +35,7 @@ import com.cherry.lib.doc.office.fc.hslf.record.Record;
 public class TimeRotationBehaviorContainer extends PositionDependentRecordContainer
 {
     private byte[] _header;
+    @Keep
     public static long RECORD_ID = 0xF12F;
     
     /**

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/TimeScaleBehaviorContainer.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/TimeScaleBehaviorContainer.java
@@ -6,8 +6,7 @@
  */
 package com.cherry.lib.doc.office.fc.hslf.record;
 
-import com.cherry.lib.doc.office.fc.hslf.record.PositionDependentRecordContainer;
-import com.cherry.lib.doc.office.fc.hslf.record.Record;
+import androidx.annotation.Keep;
 
 /**
  * TODO: a scale-animation behavior that changes the size of an object
@@ -28,6 +27,7 @@ import com.cherry.lib.doc.office.fc.hslf.record.Record;
 public class TimeScaleBehaviorContainer extends PositionDependentRecordContainer
 {
     private byte[] _header;
+    @Keep
     public static long RECORD_ID = 0xF130;
     
     /**

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/TimeSetBehaviorContainer.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/TimeSetBehaviorContainer.java
@@ -6,8 +6,7 @@
  */
 package com.cherry.lib.doc.office.fc.hslf.record;
 
-import com.cherry.lib.doc.office.fc.hslf.record.PositionDependentRecordContainer;
-import com.cherry.lib.doc.office.fc.hslf.record.Record;
+import androidx.annotation.Keep;
 
 /**
  * TODO: 文件注释
@@ -28,6 +27,7 @@ import com.cherry.lib.doc.office.fc.hslf.record.Record;
 public class TimeSetBehaviorContainer extends PositionDependentRecordContainer
 {
     private byte[] _header;
+    @Keep
     public static long RECORD_ID = 0xF131;
     
     /**

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/VisualShapeAtom.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/record/VisualShapeAtom.java
@@ -6,6 +6,8 @@
  */
 package com.cherry.lib.doc.office.fc.hslf.record;
 
+import androidx.annotation.Keep;
+
 import java.util.Hashtable;
 
 import com.cherry.lib.doc.office.fc.hslf.record.PositionDependentRecordAtom;
@@ -47,6 +49,7 @@ public class VisualShapeAtom extends PositionDependentRecordAtom
     
     
     private byte[] _header;
+    @Keep
     public static long RECORD_ID = 0x2AFB;
     
     //the target element type in the shape to which the animation is applied. 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/usermodel/PictureData.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hslf/usermodel/PictureData.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hslf.usermodel;
 
+import androidx.annotation.Keep;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.security.MessageDigest;
@@ -168,6 +170,7 @@ public abstract class PictureData
      * Must be one of the static constants defined in the <code>Picture<code> class.
      * @return concrete instance of <code>PictureData</code>
      */
+    @Keep
     public static PictureData create(int type)
     {
         PictureData pict;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/formula/Formula.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/formula/Formula.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.formula;
 
+import androidx.annotation.Keep;
+
 import java.util.Arrays;
 
 import com.cherry.lib.doc.office.fc.hssf.formula.ptg.ExpPtg;
@@ -134,6 +136,7 @@ public class Formula {
 	 * @param ptgs may be <code>null</code>
 	 * @return Never <code>null</code> (Possibly empty if the supplied <tt>ptgs</tt> is <code>null</code>)
 	 */
+	@Keep
 	public static Formula create(Ptg[] ptgs) {
 		if (ptgs == null || ptgs.length < 1) {
 			return EMPTY;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/formula/eval/ForkedEvaluator.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/formula/eval/ForkedEvaluator.java
@@ -18,6 +18,8 @@
 package com.cherry.lib.doc.office.fc.hssf.formula.eval;
 
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hssf.formula.CollaboratingWorkbooksEnvironment;
 import com.cherry.lib.doc.office.fc.hssf.formula.EvaluationCell;
 import com.cherry.lib.doc.office.fc.hssf.formula.EvaluationWorkbook;
@@ -63,12 +65,14 @@ public final class ForkedEvaluator {
 	/**
 	 * @deprecated (Sep 2009) (reduce overloading) use {@link #create(Workbook, IStabilityClassifier, UDFFinder)}
 	 */
+	@Keep
 	public static ForkedEvaluator create(Workbook wb, IStabilityClassifier stabilityClassifier) {
 		return create(wb, stabilityClassifier, null);
 	}
 	/**
 	 * @param udfFinder pass <code>null</code> for default (AnalysisToolPak only)
 	 */
+	@Keep
 	public static ForkedEvaluator create(Workbook wb, IStabilityClassifier stabilityClassifier, UDFFinder udfFinder) {
 		return new ForkedEvaluator(createEvaluationWorkbook(wb), stabilityClassifier, udfFinder);
 	}

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/formula/ptg/FuncPtg.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/formula/ptg/FuncPtg.java
@@ -18,6 +18,8 @@
 package com.cherry.lib.doc.office.fc.hssf.formula.ptg;
 
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hssf.formula.function.FunctionMetadata;
 import com.cherry.lib.doc.office.fc.hssf.formula.function.FunctionMetadataRegistry;
 import com.cherry.lib.doc.office.fc.util.LittleEndianInput;
@@ -34,6 +36,7 @@ public final class FuncPtg extends AbstractFunctionPtg {
     public final static byte sid  = 0x21;
     public final static int  SIZE = 3;
 
+    @Keep
     public static FuncPtg create(LittleEndianInput in) {
         return create(in.readUShort());
     }
@@ -42,6 +45,7 @@ public final class FuncPtg extends AbstractFunctionPtg {
         super(funcIndex, fm.getReturnClassCode(), fm.getParameterClassCodes(), fm.getMinParams());  // minParams same as max since these are not var-arg funcs
     }
 
+    @Keep
     public static FuncPtg create(int functionIndex) {
         FunctionMetadata fm = FunctionMetadataRegistry.getFunctionByIndex(functionIndex);
         if(fm == null) {

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/formula/ptg/FuncVarPtg.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/formula/ptg/FuncVarPtg.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.formula.ptg;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hssf.formula.function.FunctionMetadata;
 import com.cherry.lib.doc.office.fc.hssf.formula.function.FunctionMetadataRegistry;
 import com.cherry.lib.doc.office.fc.util.LittleEndianInput;
@@ -43,6 +45,7 @@ public final class FuncVarPtg extends AbstractFunctionPtg{
     /**Creates new function pointer from a byte array
      * usually called while reading an excel file.
      */
+    @Keep
     public static FuncVarPtg create(LittleEndianInput in)  {
         return create(in.readByte(), in.readShort());
     }
@@ -50,10 +53,12 @@ public final class FuncVarPtg extends AbstractFunctionPtg{
     /**
      * Create a function ptg from a string tokenised by the parser
      */
+    @Keep
     public static FuncVarPtg create(String pName, int numArgs) {
         return create(numArgs, lookupIndex(pName));
     }
 
+    @Keep
     private static FuncVarPtg create(int numArgs, int functionIndex) {
         FunctionMetadata fm = FunctionMetadataRegistry.getFunctionByIndex(functionIndex);
         if(fm == null) {

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/ArrayRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/ArrayRecord.java
@@ -18,6 +18,8 @@
 package com.cherry.lib.doc.office.fc.hssf.record;
 
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hssf.formula.Formula;
 import com.cherry.lib.doc.office.fc.hssf.formula.ptg.Ptg;
 import com.cherry.lib.doc.office.fc.hssf.util.CellRangeAddress8Bit;
@@ -33,7 +35,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Josh Micich
  */
 public final class ArrayRecord extends SharedValueRecordBase {
-
+	@Keep
 	public final static short sid = 0x0221;
 	private static final int OPT_ALWAYS_RECALCULATE = 0x0001;
 	private static final int OPT_CALCULATE_ON_OPEN  = 0x0002;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/AutoFilterInfoRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/AutoFilterInfoRecord.java
@@ -19,6 +19,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -31,6 +33,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 public final class AutoFilterInfoRecord
     extends StandardRecord
 {
+    @Keep
     public final static short sid = 0x9D;
     /**
      * Number of AutoFilter drop-down arrows on the sheet

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/BOFRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/BOFRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
@@ -33,6 +35,7 @@ public final class BOFRecord extends StandardRecord {
     /**
      * for BIFF8 files the BOF is 0x809.  For earlier versions it was 0x09 or 0x(biffversion)09
      */
+    @Keep
     public final static short sid = 0x809;
 
     /** suggested default (0x0600 - BIFF8) */

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/BackupRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/BackupRecord.java
@@ -19,6 +19,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -33,6 +35,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 public final class BackupRecord
     extends StandardRecord
 {
+    @Keep
     public final static short sid = 0x40;
     private short             field_1_backup;   // = 0;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/BlankRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/BlankRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
@@ -29,6 +31,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @version 2.0-pre
  */
 public final class BlankRecord extends StandardRecord implements CellValueRecordInterface {
+    @Keep
     public final static short sid = 0x0201;
     private int             field_1_row;
     private short             field_2_col;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/BookBoolRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/BookBoolRecord.java
@@ -19,6 +19,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -33,6 +35,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 public final class BookBoolRecord
     extends StandardRecord
 {
+    @Keep
     public final static short sid = 0xDA;
     private short             field_1_save_link_values;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/BoolErrRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/BoolErrRecord.java
@@ -18,6 +18,8 @@
 package com.cherry.lib.doc.office.fc.hssf.record;
 
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.ss.usermodel.ErrorConstants;
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
@@ -30,6 +32,8 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Jason Height (jheight at chariot dot net dot au)
  */
 public final class BoolErrRecord extends CellRecord {
+
+	@Keep
 	public final static short sid = 0x0205;
 	private int _value;
 	/**

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/BottomMarginRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/BottomMarginRecord.java
@@ -19,6 +19,8 @@
 package com.cherry.lib.doc.office.fc.hssf.record;
 
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 
@@ -28,6 +30,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Shawn Laubach (slaubach at apache dot org)
  */
 public final class BottomMarginRecord extends StandardRecord implements Margin {
+    @Keep
     public final static short sid = 0x29;
     private double field_1_margin;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/BoundSheetRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/BoundSheetRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -40,6 +42,7 @@ import com.cherry.lib.doc.office.fc.util.StringUtil;
  * @author Sergei Kozello (sergeikozello at mail.ru)
  */
 public final class BoundSheetRecord extends StandardRecord {
+	@Keep
 	public final static short sid = 0x0085;
 
 	private static final BitField hiddenFlag = BitFieldFactory.getInstance(0x01);

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/CFHeaderRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/CFHeaderRecord.java
@@ -18,6 +18,8 @@
 package com.cherry.lib.doc.office.fc.hssf.record;
 
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hssf.record.cf.CellRangeUtil;
 import com.cherry.lib.doc.office.fc.ss.util.CellRangeAddressList;
 import com.cherry.lib.doc.office.fc.ss.util.HSSFCellRangeAddress;
@@ -30,6 +32,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Dmitriy Kumshayev
  */
 public final class CFHeaderRecord extends StandardRecord {
+	@Keep
 	public static final short sid = 0x01B0;
 
 	private int field_1_numcf;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/CFRuleRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/CFRuleRecord.java
@@ -18,6 +18,8 @@
 package com.cherry.lib.doc.office.fc.hssf.record;
 
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hssf.formula.Formula;
 import com.cherry.lib.doc.office.fc.hssf.formula.FormulaType;
 import com.cherry.lib.doc.office.fc.hssf.formula.ptg.Ptg;
@@ -39,7 +41,7 @@ import com.cherry.lib.doc.office.ss.model.XLSModel.AWorkbook;
  * @author Dmitriy Kumshayev
  */
 public final class CFRuleRecord extends StandardRecord {
-
+	@Keep
 	public static final short sid = 0x01B1;
 
 	public static final class ComparisonOperator {
@@ -137,7 +139,8 @@ public final class CFRuleRecord extends StandardRecord {
 	/**
 	 * Creates a new comparison operation rule
 	 */
-    public static CFRuleRecord create(ASheet sheet, String formulaText) {
+	@Keep
+	public static CFRuleRecord create(ASheet sheet, String formulaText) {
         Ptg[] formula1 = parseFormula(formulaText, sheet);
         return new CFRuleRecord(CONDITION_TYPE_FORMULA, ComparisonOperator.NO_COMPARISON,
                 formula1, null);
@@ -145,6 +148,7 @@ public final class CFRuleRecord extends StandardRecord {
 	/**
 	 * Creates a new comparison operation rule
 	 */
+	@Keep
 	public static CFRuleRecord create(ASheet sheet, byte comparisonOperation,
 			String formulaText1, String formulaText2) {
 		Ptg[] formula1 = parseFormula(formulaText1, sheet);

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/CRNCountRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/CRNCountRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 /**
  * XCT - CRN Count <P>
@@ -26,6 +28,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Josh Micich
  */
 public final class CRNCountRecord extends StandardRecord {
+	@Keep
 	public final static short sid = 0x59;
 
 	private static final short DATA_SIZE = 4;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/CRNRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/CRNRecord.java
@@ -18,6 +18,8 @@
 package com.cherry.lib.doc.office.fc.hssf.record;
 
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.constant.fc.ConstantValueParser;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
@@ -30,6 +32,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author josh micich
  */
 public final class CRNRecord extends StandardRecord {
+	@Keep
 	public final static short sid = 0x005A;
 
 	private int	 field_1_last_column_index;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/CalcCountRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/CalcCountRecord.java
@@ -19,6 +19,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -38,6 +40,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 public final class CalcCountRecord
     extends StandardRecord
 {
+    @Keep
     public final static short sid = 0xC;
     private short             field_1_iterations;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/ColumnInfoRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/ColumnInfoRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.BitField;
 import com.cherry.lib.doc.office.fc.util.BitFieldFactory;
 import com.cherry.lib.doc.office.fc.util.HexDump;
@@ -29,6 +31,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Andrew C. Oliver (acoliver at apache dot org)
  */
 public final class ColumnInfoRecord extends StandardRecord {
+    @Keep
     public static final short sid = 0x007D;
 
     private int _firstCol;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/ContinueRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/ContinueRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
@@ -29,6 +31,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Csaba Nagy (ncsaba at yahoo dot com)
  */
 public final class ContinueRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x003C;
     private byte[] _data;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/CountryRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/CountryRecord.java
@@ -19,6 +19,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -34,6 +36,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 public final class CountryRecord
     extends StandardRecord
 {
+    @Keep
     public final static short sid = 0x8c;
 
     // 1 for US

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DBCellRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DBCellRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
@@ -28,6 +30,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Jason Height
  */
 public final class DBCellRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x00D7;
     public final static int BLOCK_SIZE = 32;
     

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DSFRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DSFRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.BitField;
 import com.cherry.lib.doc.office.fc.util.BitFieldFactory;
 import com.cherry.lib.doc.office.fc.util.HexDump;
@@ -30,6 +32,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Andrew C. Oliver (acoliver at apache dot org)
  */
 public final class DSFRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x0161;
 
     private static final BitField biff5BookStreamFlag = BitFieldFactory.getInstance(0x0001);

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DVALRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DVALRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -26,6 +28,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Dragos Buleandra (dragos.buleandra@trade2b.ro)
  */
 public final class DVALRecord extends StandardRecord {
+	@Keep
 	public final static short sid = 0x01B2;
 
 	/** Options of the DVAL */

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DVRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DVRecord.java
@@ -18,6 +18,8 @@
 package com.cherry.lib.doc.office.fc.hssf.record;
 
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hssf.formula.Formula;
 import com.cherry.lib.doc.office.fc.hssf.formula.ptg.Ptg;
 import com.cherry.lib.doc.office.fc.hssf.record.common.UnicodeString;
@@ -39,6 +41,7 @@ import com.cherry.lib.doc.office.fc.util.StringUtil;
  * @author Josh Micich
  */
 public final class DVRecord extends StandardRecord {
+	@Keep
 	public final static short sid = 0x01BE;
 	
 	/** the unicode string used for error/prompt title/text when not present */

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DateWindow1904Record.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DateWindow1904Record.java
@@ -19,6 +19,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -33,6 +35,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 public final class DateWindow1904Record
     extends StandardRecord
 {
+    @Keep
     public final static short sid = 0x22;
     private short             field_1_window;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DefaultColWidthRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DefaultColWidthRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -29,6 +31,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @version 2.0-pre
  */
 public final class DefaultColWidthRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x0055;
     private int             field_1_col_width;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DefaultRowHeightRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DefaultRowHeightRecord.java
@@ -19,6 +19,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -34,6 +36,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 public final class DefaultRowHeightRecord
     extends StandardRecord
 {
+    @Keep
     public final static short sid = 0x225;
     private short             field_1_option_flags;
     private short             field_2_row_height;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DeltaRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DeltaRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -27,6 +29,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Jason Height (jheight at chariot dot net dot au)
  */
 public final class DeltaRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x0010;
     public final static double DEFAULT_VALUE = 0.0010;   // should be .001
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DimensionsRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DimensionsRecord.java
@@ -19,6 +19,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -34,6 +36,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 public final class DimensionsRecord
     extends StandardRecord
 {
+    @Keep
     public final static short sid = 0x200;
     private int               field_1_first_row;
     private int               field_2_last_row;   // plus 1

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DrawingGroupRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DrawingGroupRecord.java
@@ -19,6 +19,8 @@ package com.cherry.lib.doc.office.fc.hssf.record;
 
 
 
+import androidx.annotation.Keep;
+
 import java.util.Iterator;
 import java.util.List;
 
@@ -29,6 +31,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndian;
 
 
 public final class DrawingGroupRecord extends AbstractEscherHolderRecord {
+    @Keep
     public static final short sid = 0xEB;
 
     static final int MAX_RECORD_SIZE = 8228;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DrawingRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DrawingRecord.java
@@ -17,12 +17,15 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 /**
  * DrawingRecord (0x00EC)<p/>
  *
  */
 public final class DrawingRecord extends StandardRecord {
+    @Keep
     public static final short sid = 0x00EC;
 
 	private static final byte[] EMPTY_BYTE_ARRAY = { };

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DrawingRecordForBiffViewer.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/DrawingRecordForBiffViewer.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import java.io.ByteArrayInputStream;
 
 
@@ -25,6 +27,7 @@ import java.io.ByteArrayInputStream;
  * to be seeing this.
  */
 public final class DrawingRecordForBiffViewer extends AbstractEscherHolderRecord {
+    @Keep
     public static final short sid = 0xEC;
 
     public DrawingRecordForBiffViewer()

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/EOFRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/EOFRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -30,6 +32,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @version 2.0-pre
  */
 public final class EOFRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x0A;
 	public static final int ENCODED_SIZE = 4;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/EmbeddedObjectRefSubRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/EmbeddedObjectRefSubRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import java.io.ByteArrayInputStream;
 
 import com.cherry.lib.doc.office.fc.hssf.formula.ptg.Area3DPtg;
@@ -41,6 +43,7 @@ import com.cherry.lib.doc.office.fc.util.StringUtil;
  * @author Daniel Noll
  */
 public final class EmbeddedObjectRefSubRecord extends SubRecord {
+	@Keep
 	public static final short sid = 0x0009;
 
 	private static final byte[] EMPTY_BYTE_ARRAY = { };

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/EndSubRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/EndSubRecord.java
@@ -17,6 +17,8 @@
         
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianInput;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
@@ -28,6 +30,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Glen Stampoultzis (glens at apache.org)
  */
 public final class EndSubRecord extends SubRecord {
+    @Keep
     public final static short sid = 0x0000; // Note - zero sid is somewhat unusual (compared to plain Records)
     private static final int ENCODED_SIZE = 0;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/EscherAggregate.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/EscherAggregate.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -73,6 +75,7 @@ import com.cherry.lib.doc.office.ss.model.XLSModel.AWorkbook;
  * @author Glen Stampoultzis (glens at apache.org)
  */
 public final class EscherAggregate extends AbstractEscherHolderRecord {
+	@Keep
 	public static final short sid = 9876; // not a real sid - dummy value
 	private static POILogger log = POILogFactory.getLogger(EscherAggregate.class);
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/ExtSSTRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/ExtSSTRecord.java
@@ -19,6 +19,8 @@ package com.cherry.lib.doc.office.fc.hssf.record;
 
 
 
+import androidx.annotation.Keep;
+
 import java.util.ArrayList;
 
 import com.cherry.lib.doc.office.fc.hssf.record.cont.ContinuableRecord;
@@ -36,6 +38,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Jason Height (jheight at apache dot org)
  */
 public final class ExtSSTRecord extends ContinuableRecord {
+    @Keep
     public final static short sid = 0x00FF;
     public static final int DEFAULT_BUCKET_SIZE = 8;
     //Can't seem to find this documented but from the biffviewer it is clear that

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/ExternSheetRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/ExternSheetRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,7 +33,8 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  */
 public class ExternSheetRecord extends StandardRecord {
 
-    public final static short sid = 0x0017;
+	@Keep
+	public final static short sid = 0x0017;
 	private List<RefSubRecord> _list;
 	
 	private static final class RefSubRecord {

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/ExternalNameRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/ExternalNameRecord.java
@@ -18,6 +18,8 @@
 package com.cherry.lib.doc.office.fc.hssf.record;
 
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.constant.fc.ConstantValueParser;
 import com.cherry.lib.doc.office.fc.hssf.formula.Formula;
 import com.cherry.lib.doc.office.fc.hssf.formula.ptg.Ptg;
@@ -32,6 +34,7 @@ import com.cherry.lib.doc.office.fc.util.StringUtil;
  */
 public final class ExternalNameRecord extends StandardRecord {
 
+	@Keep
 	public final static short sid = 0x0023; // as per BIFF8. (some old versions used 0x223)
 
 	private static final int OPT_BUILTIN_NAME          = 0x0001;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/FeatRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/FeatRecord.java
@@ -18,6 +18,8 @@
 package com.cherry.lib.doc.office.fc.hssf.record;
 
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hssf.record.common.FeatFormulaErr2;
 import com.cherry.lib.doc.office.fc.hssf.record.common.FeatProtection;
 import com.cherry.lib.doc.office.fc.hssf.record.common.FeatSmartTag;
@@ -34,6 +36,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  *  up with a {@link FeatHdrRecord}.
  */
 public final class FeatRecord extends StandardRecord  {
+	@Keep
 	public final static short sid = 0x0868;
 	
 	private FtrHeader futureHeader;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/FilePassRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/FilePassRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
@@ -28,6 +30,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Jason Height (jheight at chariot dot net dot au)
  */
 public final class FilePassRecord extends StandardRecord {
+	@Keep
 	public final static short sid = 0x002F;
 	private int _encryptionType;
 	private int _encryptionInfo;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/FileSharingRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/FileSharingRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 import com.cherry.lib.doc.office.fc.util.StringUtil;
 
@@ -29,6 +31,7 @@ import com.cherry.lib.doc.office.fc.util.StringUtil;
  */
 public final class FileSharingRecord extends StandardRecord {
 
+    @Keep
     public final static short sid = 0x005B;
     private short             field_1_readonly;
     private short             field_2_password;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/FooterRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/FooterRecord.java
@@ -18,6 +18,8 @@
 package com.cherry.lib.doc.office.fc.hssf.record;
 
 
+import androidx.annotation.Keep;
+
 /**
  * Title:        Footer Record (0x0015) <p/>
  * Description:  Specifies the footer for a sheet<P>
@@ -28,6 +30,7 @@ package com.cherry.lib.doc.office.fc.hssf.record;
  *
  */
 public final class FooterRecord extends HeaderFooterBase {
+	@Keep
 	public final static short sid = 0x0015;
 
 	public FooterRecord(String text) {

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/FormatRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/FormatRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 import com.cherry.lib.doc.office.fc.util.StringUtil;
@@ -30,6 +32,7 @@ import com.cherry.lib.doc.office.fc.util.StringUtil;
  * @author Shawn M. Laubach (slaubach at apache dot org)
  */
 public final class FormatRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x041E;
 
     private final int field_1_index_code;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/FormulaRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/FormulaRecord.java
@@ -18,6 +18,8 @@
 package com.cherry.lib.doc.office.fc.hssf.record;
 
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hssf.formula.Formula;
 import com.cherry.lib.doc.office.fc.hssf.formula.eval.ErrorEval;
 import com.cherry.lib.doc.office.fc.hssf.formula.ptg.Ptg;
@@ -38,6 +40,7 @@ import com.cherry.lib.doc.office.ss.model.baseModel.Cell;
  */
 public final class FormulaRecord extends CellRecord {
 
+	@Keep
 	public static final short sid = 0x0006;   // docs say 406...because of a bug Microsoft support site article #Q184647)
 	private static int FIXED_SIZE = 14; // double + short + int
 
@@ -74,6 +77,7 @@ public final class FormulaRecord extends CellRecord {
 		 * @return <code>null</code> if the double value encoded by <tt>valueLongBits</tt> 
 		 * is a normal (non NaN) double value.
 		 */
+		@Keep
 		public static SpecialCachedValue create(long valueLongBits) {
 			if ((BIT_MARKER & valueLongBits) != BIT_MARKER) {
 				return null;
@@ -128,6 +132,7 @@ public final class FormulaRecord extends CellRecord {
 		public static SpecialCachedValue createCachedErrorCode(int errorCode) {
 			return create(ERROR_CODE, errorCode);
 		}
+		@Keep
 		private static SpecialCachedValue create(int code, int data) {
 			byte[] vd = {
 					(byte) code,

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/FtCblsSubRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/FtCblsSubRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndianInput;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
@@ -28,6 +30,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Yegor Kozlov
  */
 public final class FtCblsSubRecord extends SubRecord {
+    @Keep
     public final static short sid = 0x0C;
     private static final int ENCODED_SIZE = 20;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/GridsetRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/GridsetRecord.java
@@ -19,6 +19,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -37,6 +39,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 public final class GridsetRecord
     extends StandardRecord
 {
+    @Keep
     public final static short sid = 0x82;
     public short              field_1_gridset_flag;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/GroupMarkerSubRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/GroupMarkerSubRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndianInput;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
@@ -28,6 +30,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Glen Stampoultzis (glens at apache.org)
  */
 public final class GroupMarkerSubRecord extends SubRecord {
+    @Keep
     public final static short sid = 0x0006;
 
     private static final byte[] EMPTY_BYTE_ARRAY = { };

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/GutsRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/GutsRecord.java
@@ -19,6 +19,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -33,6 +35,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 public final class GutsRecord
     extends StandardRecord
 {
+    @Keep
     public final static short sid = 0x80;
     private short             field_1_left_row_gutter;   // size of the row gutter to the left of the rows
     private short             field_2_top_col_gutter;    // size of the column gutter above the columns

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/HCenterRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/HCenterRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -28,6 +30,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @version 2.0-pre
  */
 public final class HCenterRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x0083;
     private short             field_1_hcenter;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/HeaderFooterRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/HeaderFooterRecord.java
@@ -19,6 +19,8 @@ package com.cherry.lib.doc.office.fc.hssf.record;
 
 
 
+import androidx.annotation.Keep;
+
 import java.util.Arrays;
 
 import com.cherry.lib.doc.office.fc.hssf.record.aggregates.PageSettingsBlock;
@@ -34,6 +36,7 @@ public final class HeaderFooterRecord extends StandardRecord {
 
     private static final byte[] BLANK_GUID = new byte[16];
 
+    @Keep
     public final static short sid = 0x089C;
 	private byte[] _rawData;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/HeaderRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/HeaderRecord.java
@@ -18,6 +18,8 @@
 package com.cherry.lib.doc.office.fc.hssf.record;
 
 
+import androidx.annotation.Keep;
+
 /**
  * Title:        Header Record<P>
  * Description:  Specifies a header for a sheet<P>
@@ -27,6 +29,7 @@ package com.cherry.lib.doc.office.fc.hssf.record;
  * @author Jason Height (jheight at chariot dot net dot au)
  */
 public final class HeaderRecord extends HeaderFooterBase {
+	@Keep
 	public final static short sid = 0x0014;
 
 	public HeaderRecord(String text) {

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/HorizontalPageBreakRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/HorizontalPageBreakRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import java.util.Iterator;
 
 import com.cherry.lib.doc.office.fc.hssf.record.PageBreakRecord.Break;
@@ -29,6 +31,7 @@ import com.cherry.lib.doc.office.fc.hssf.record.PageBreakRecord.Break;
  */
 public final class HorizontalPageBreakRecord extends PageBreakRecord {
 
+	@Keep
 	public static final short sid = 0x001B;
 
 	/**

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/HyperlinkRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/HyperlinkRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -42,6 +44,7 @@ import com.cherry.lib.doc.office.fc.util.StringUtil;
  * @author      Yegor Kozlov (yegor at apache dot org)
  */
 public final class HyperlinkRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x01B8;
     private POILogger logger = POILogFactory.getLogger(getClass());
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/IndexRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/IndexRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.IntList;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
@@ -30,6 +32,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Jason Height (jheight at chariot dot net dot au)
  */
 public class IndexRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x020B;
     private int                field_2_first_row;       // first row on the sheet
     private int                field_3_last_row_add1;   // last row

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/InterfaceEndRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/InterfaceEndRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -28,6 +30,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  */
 public final class InterfaceEndRecord extends StandardRecord {
 
+    @Keep
     public static final short sid = 0x00E2;
     public static final InterfaceEndRecord instance = new InterfaceEndRecord();
 
@@ -35,6 +38,7 @@ public final class InterfaceEndRecord extends StandardRecord {
         // enforce singleton
     }
 
+    @Keep
     public static Record create(RecordInputStream in) {
         switch (in.remaining()) {
             case 0:

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/InterfaceHdrRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/InterfaceHdrRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
@@ -27,6 +29,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Andrew C. Oliver (acoliver at apache dot org)
  */
 public final class InterfaceHdrRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x00E1;
     private final int _codepage;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/IterationRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/IterationRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.BitField;
 import com.cherry.lib.doc.office.fc.util.BitFieldFactory;
 import com.cherry.lib.doc.office.fc.util.HexDump;
@@ -33,6 +35,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Jason Height (jheight at chariot dot net dot au)
  */
 public final class IterationRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x0011;
 
     private static final BitField iterationOn = BitFieldFactory.getInstance(0x0001);

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/LabelSSTRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/LabelSSTRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
@@ -29,6 +31,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Jason Height (jheight at chariot dot net dot au)
  */
 public final class LabelSSTRecord extends CellRecord {
+    @Keep
     public final static short sid = 0xfd;
     private int field_4_sst_index;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/LeftMarginRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/LeftMarginRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -26,6 +28,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  */
 public final class LeftMarginRecord extends StandardRecord implements Margin
 {
+    @Keep
     public final static short sid = 0x0026;
     private double field_1_margin;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/MMSRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/MMSRecord.java
@@ -19,6 +19,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -33,6 +35,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 public final class MMSRecord
     extends StandardRecord
 {
+    @Keep
     public final static short sid = 0xC1;
     private byte              field_1_addMenuCount;   // = 0;
     private byte              field_2_delMenuCount;   // = 0;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/MergeCellsRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/MergeCellsRecord.java
@@ -18,6 +18,8 @@
 package com.cherry.lib.doc.office.fc.hssf.record;
 
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.ss.util.CellRangeAddressList;
 import com.cherry.lib.doc.office.fc.ss.util.HSSFCellRangeAddress;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
@@ -30,6 +32,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Andrew C. Oliver (acoliver at apache dot org)
  */
 public final class MergeCellsRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x00E5;
     /** sometimes the regions array is shared with other MergedCellsRecords */ 
     private HSSFCellRangeAddress[] _regions;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/MulBlankRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/MulBlankRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -29,6 +31,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @see BlankRecord
  */
 public final class MulBlankRecord extends StandardRecord {
+	@Keep
 	public final static short sid = 0x00BE;
 
 	private final int _row;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/MulRKRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/MulRKRecord.java
@@ -18,6 +18,8 @@
 package com.cherry.lib.doc.office.fc.hssf.record;
 
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hssf.util.RKUtil;
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
@@ -33,6 +35,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @version 2.0-pre
  */
 public final class MulRKRecord extends StandardRecord {
+	@Keep
 	public final static short sid = 0x00BD;
 
 	private int	 field_1_row;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/NameCommentRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/NameCommentRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndianInput;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
@@ -33,6 +35,7 @@ import com.cherry.lib.doc.office.fc.util.StringUtil;
  * @author Andrew Shirley (aks at corefiling.co.uk)
  */
 public final class NameCommentRecord extends StandardRecord {
+  @Keep
   public final static short sid = 0x0894;
 
   private final short field_1_record_type;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/NameRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/NameRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hssf.formula.Formula;
 import com.cherry.lib.doc.office.fc.hssf.formula.ptg.Area3DPtg;
 import com.cherry.lib.doc.office.fc.hssf.formula.ptg.Ptg;
@@ -39,7 +41,8 @@ import com.cherry.lib.doc.office.fc.util.StringUtil;
  * @author Petr Udalau - added method setFunction(boolean)
  */
 public final class NameRecord extends ContinuableRecord {
-    public final static short sid = 0x0018;
+	@Keep
+	public final static short sid = 0x0018;
 	/**Included for completeness sake, not implemented */
 	public final static byte  BUILTIN_CONSOLIDATE_AREA      = 1;
 	/**Included for completeness sake, not implemented */

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/NoteRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/NoteRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 import com.cherry.lib.doc.office.fc.util.StringUtil;
 
@@ -26,6 +28,7 @@ import com.cherry.lib.doc.office.fc.util.StringUtil;
  * @author Yegor Kozlov
  */
 public final class NoteRecord extends StandardRecord {
+	@Keep
 	public final static short sid = 0x001C;
 
 	public static final NoteRecord[] EMPTY_ARRAY = { };

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/NoteStructureSubRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/NoteStructureSubRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndianInput;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
@@ -32,6 +34,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Yegor Kozlov
  */
 public final class NoteStructureSubRecord extends SubRecord {
+    @Keep
     public final static short sid = 0x0D;
     private static final int ENCODED_SIZE = 22;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/NumberRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/NumberRecord.java
@@ -18,6 +18,8 @@
 package com.cherry.lib.doc.office.fc.hssf.record;
 
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.ss.util.NumberToTextConverter;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
@@ -29,6 +31,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Jason Height (jheight at chariot dot net dot au)
  */
 public final class NumberRecord extends CellRecord {
+    @Keep
     public static final short sid = 0x0203;
     private double field_4_value;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/ObjRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/ObjRecord.java
@@ -17,6 +17,8 @@
         
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +37,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianInputStream;
  * @author Glen Stampoultzis (glens at apache.org)
  */
 public final class ObjRecord extends Record {
+	@Keep
 	public final static short sid = 0x005D;
 
 	private static final int NORMAL_PAD_ALIGNMENT = 2;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/ObjectProtectRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/ObjectProtectRecord.java
@@ -19,6 +19,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -34,6 +36,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 public final class ObjectProtectRecord
     extends StandardRecord
 {
+    @Keep
     public final static short sid = 0x63;
     private short             field_1_protect;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/PaletteRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/PaletteRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,6 +32,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  *
  */
 public final class PaletteRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x0092;
     /** The standard size of an XLS palette */
     public final static byte STANDARD_PALETTE_SIZE = (byte) 56;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/PasswordRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/PasswordRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
@@ -28,6 +30,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  *
  */
 public final class PasswordRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x0013;
     private int field_1_password;   // not sure why this is only 2 bytes, but it is... go figure
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/PasswordRev4Record.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/PasswordRev4Record.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
@@ -27,6 +29,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Andrew C. Oliver (acoliver at apache dot org)
  */
 public final class PasswordRev4Record extends StandardRecord {
+    @Keep
     public final static short sid = 0x01BC;
     private int field_1_password;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/PrecisionRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/PrecisionRecord.java
@@ -19,6 +19,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -33,6 +35,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 public final class PrecisionRecord
     extends StandardRecord
 {
+    @Keep
     public final static short sid = 0xE;
     public short              field_1_precision;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/PrintGridlinesRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/PrintGridlinesRecord.java
@@ -19,6 +19,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -33,6 +35,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 public final class PrintGridlinesRecord
     extends StandardRecord
 {
+    @Keep
     public final static short sid = 0x2b;
     private short             field_1_print_gridlines;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/ProtectRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/ProtectRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.BitField;
 import com.cherry.lib.doc.office.fc.util.BitFieldFactory;
 import com.cherry.lib.doc.office.fc.util.HexDump;
@@ -31,6 +33,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Andrew C. Oliver (acoliver at apache dot org)
  */
 public final class ProtectRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x0012;
 
     private static final BitField protectFlag = BitFieldFactory.getInstance(0x0001);

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/ProtectionRev4Record.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/ProtectionRev4Record.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.BitField;
 import com.cherry.lib.doc.office.fc.util.BitFieldFactory;
 import com.cherry.lib.doc.office.fc.util.HexDump;
@@ -29,6 +31,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Andrew C. Oliver (acoliver at apache dot org)
  */
 public final class ProtectionRev4Record extends StandardRecord {
+    @Keep
     public final static short sid = 0x01AF;
 
     private static final BitField protectedFlag = BitFieldFactory.getInstance(0x0001);

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/RecalcIdRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/RecalcIdRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
@@ -33,6 +35,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Luc Girardin (luc dot girardin at macrofocus dot com)
  */
 public final class RecalcIdRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x01C1;
     private final int _reserved0;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/RecordFactory.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/RecordFactory.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -118,6 +120,7 @@ public final class RecordFactory
             _c = c;
         }
 
+        @Keep
         public Record create(RecordInputStream in)
         {
             Object[] args = {in,};
@@ -164,6 +167,7 @@ public final class RecordFactory
             _m = m;
         }
 
+        @Keep
         public Record create(RecordInputStream in)
         {
             Object[] args = {in,};

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/RefreshAllRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/RefreshAllRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.BitField;
 import com.cherry.lib.doc.office.fc.util.BitFieldFactory;
 import com.cherry.lib.doc.office.fc.util.HexDump;
@@ -30,6 +32,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Andrew C. Oliver (acoliver at apache dot org)
  */
 public final class RefreshAllRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x01B7;
 
     private static final BitField refreshFlag = BitFieldFactory.getInstance(0x0001);

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/RightMarginRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/RightMarginRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -25,6 +27,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Shawn Laubach (slaubach at apache dot org)
  */
 public final class RightMarginRecord extends StandardRecord implements Margin {
+    @Keep
     public final static short sid = 0x27;
     private double field_1_margin;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/RowRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/RowRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.BitField;
 import com.cherry.lib.doc.office.fc.util.BitFieldFactory;
 import com.cherry.lib.doc.office.fc.util.HexDump;
@@ -31,6 +33,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @version 2.0-pre
  */
 public final class RowRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x0208;
 
     public static final int ENCODED_SIZE = 20;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/SSTRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/SSTRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import java.util.Iterator;
 
 import com.cherry.lib.doc.office.fc.hssf.record.common.UnicodeString;
@@ -43,6 +45,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianConsts;
  * @see com.cherry.lib.doc.office.fc.hssf.record.ContinueRecord
  */
 public final class SSTRecord extends ContinuableRecord {
+    @Keep
     public static final short sid = 0x00FC;
 
     private static final UnicodeString EMPTY_STRING = new UnicodeString("");

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/SaveRecalcRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/SaveRecalcRecord.java
@@ -19,6 +19,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -33,6 +35,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 public final class SaveRecalcRecord
     extends StandardRecord
 {
+    @Keep
     public final static short sid = 0x5f;
     private short             field_1_recalc;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/ScenarioProtectRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/ScenarioProtectRecord.java
@@ -19,6 +19,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -35,6 +37,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 public final class ScenarioProtectRecord
     extends StandardRecord
 {
+    @Keep
     public final static short sid = 0xdd;
     private short             field_1_protect;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/SelectionRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/SelectionRecord.java
@@ -18,6 +18,8 @@
 package com.cherry.lib.doc.office.fc.hssf.record;
 
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hssf.util.CellRangeAddress8Bit;
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
@@ -34,6 +36,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Glen Stampoultzis (glens at apache.org)
  */
 public final class SelectionRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x001D;
     private byte        field_1_pane;
     private int         field_2_row_active_cell;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/StringRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/StringRecord.java
@@ -18,6 +18,8 @@
 package com.cherry.lib.doc.office.fc.hssf.record;
 
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hssf.record.cont.ContinuableRecord;
 import com.cherry.lib.doc.office.fc.hssf.record.cont.ContinuableRecordOutput;
 import com.cherry.lib.doc.office.fc.util.StringUtil;
@@ -32,7 +34,8 @@ import com.cherry.lib.doc.office.fc.util.StringUtil;
  */
 public final class StringRecord extends ContinuableRecord {
 
-	public final static short sid = 0x0207;
+    @Keep
+    public final static short sid = 0x0207;
 
 	private boolean _is16bitUnicode;
 	private String _text;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/StyleRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/StyleRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.BitField;
 import com.cherry.lib.doc.office.fc.util.BitFieldFactory;
 import com.cherry.lib.doc.office.fc.util.HexDump;
@@ -31,6 +33,7 @@ import com.cherry.lib.doc.office.fc.util.StringUtil;
  * @author aviks : string fixes for UserDefined Style
  */
 public final class StyleRecord extends StandardRecord {
+	@Keep
 	public final static short sid = 0x0293;
 
 	private static final BitField styleIndexMask = BitFieldFactory.getInstance(0x0FFF);

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/SupBookRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/SupBookRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 import com.cherry.lib.doc.office.fc.util.StringUtil;
 
@@ -31,6 +33,7 @@ import com.cherry.lib.doc.office.fc.util.StringUtil;
  */
 public final class SupBookRecord extends StandardRecord {
 
+    @Keep
     public final static short sid = 0x01AE;
 
     private static final short SMALL_RECORD_SIZE = 4;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/TabIdRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/TabIdRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -28,6 +30,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  *
  */
 public final class TabIdRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x013D;
     private static final short[] EMPTY_SHORT_ARRAY = { };
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/TableRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/TableRecord.java
@@ -18,6 +18,8 @@
 package com.cherry.lib.doc.office.fc.hssf.record;
 
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hssf.formula.ptg.TblPtg;
 import com.cherry.lib.doc.office.fc.hssf.util.CellRangeAddress8Bit;
 import com.cherry.lib.doc.office.fc.hssf.util.CellReference;
@@ -37,6 +39,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * See p536 of the June 08 binary docs
  */
 public final class TableRecord extends SharedValueRecordBase {
+	@Keep
 	public static final short sid = 0x0236;
 
 	private static final BitField alwaysCalc      = BitFieldFactory.getInstance(0x0001);

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/TableStylesRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/TableStylesRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.HexDump;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 import com.cherry.lib.doc.office.fc.util.StringUtil;
@@ -27,6 +29,7 @@ import com.cherry.lib.doc.office.fc.util.StringUtil;
  * @author Patrick Cheng
  */
 public final class TableStylesRecord extends StandardRecord {
+	@Keep
 	public static final short sid = 0x088E;
 	
 	private int rt;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/TopMarginRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/TopMarginRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -25,6 +27,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Shawn Laubach (slaubach at apache dot org)
  */
 public final class TopMarginRecord extends StandardRecord implements Margin {
+    @Keep
     public final static short sid = 0x28;
     private double field_1_margin;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/UncalcedRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/UncalcedRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -28,6 +30,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Olivier Leprince
  */
 public final class UncalcedRecord extends StandardRecord  {
+	@Keep
 	public final static short sid = 0x005E;
 
     private short _reserved;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/UserSViewBegin.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/UserSViewBegin.java
@@ -19,6 +19,8 @@ package com.cherry.lib.doc.office.fc.hssf.record;
 
 
 
+import androidx.annotation.Keep;
+
 import java.util.Arrays;
 
 import com.cherry.lib.doc.office.fc.hssf.record.aggregates.PageSettingsBlock;
@@ -35,6 +37,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  */
 public final class UserSViewBegin extends StandardRecord {
 
+    @Keep
     public final static short sid = 0x01AA;
 	private byte[] _rawData;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/UserSViewEnd.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/UserSViewEnd.java
@@ -19,6 +19,8 @@ package com.cherry.lib.doc.office.fc.hssf.record;
 
 
 
+import androidx.annotation.Keep;
+
 import java.util.Arrays;
 
 import com.cherry.lib.doc.office.fc.hssf.record.aggregates.PageSettingsBlock;
@@ -32,6 +34,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  */
 public final class UserSViewEnd extends StandardRecord {
 
+    @Keep
     public final static short sid = 0x01AB;
 	private byte[] _rawData;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/VCenterRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/VCenterRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -29,6 +31,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  */
 
 public final class VCenterRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x84;
     private int field_1_vcenter;
 

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/VerticalPageBreakRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/VerticalPageBreakRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import java.util.Iterator;
 
 
@@ -28,6 +30,7 @@ import java.util.Iterator;
  */
 public final class VerticalPageBreakRecord extends PageBreakRecord {
 
+	@Keep
 	public static final short sid = 0x001A;
 
 	/**

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/WindowProtectRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/WindowProtectRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.BitField;
 import com.cherry.lib.doc.office.fc.util.BitFieldFactory;
 import com.cherry.lib.doc.office.fc.util.HexDump;
@@ -29,6 +31,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @author Andrew C. Oliver (acoliver at apache dot org)
  */
 public final class WindowProtectRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x0019;
 
     private static final BitField settingsProtectedFlag = BitFieldFactory.getInstance(0x0001);

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/WindowTwoRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/WindowTwoRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.BitField;
 import com.cherry.lib.doc.office.fc.util.BitFieldFactory;
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
@@ -30,6 +32,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @version 2.0-pre
  */
 public final class WindowTwoRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x023E;
 
     // bitfields

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/WriteAccessRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/WriteAccessRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import java.util.Arrays;
 
 import com.cherry.lib.doc.office.fc.util.LittleEndian;
@@ -36,6 +38,7 @@ import com.cherry.lib.doc.office.fc.util.StringUtil;
  * @author Andrew C. Oliver (acoliver at apache dot org)
  */
 public final class WriteAccessRecord extends StandardRecord {
+	@Keep
 	public final static short sid = 0x005C;
 
 	private static final byte PAD_CHAR = (byte) ' ';

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/WriteProtectRecord.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/WriteProtectRecord.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
 
 /**
@@ -26,6 +28,7 @@ import com.cherry.lib.doc.office.fc.util.LittleEndianOutput;
  * @version 3.0-pre
  */
 public final class WriteProtectRecord extends StandardRecord {
+    @Keep
     public final static short sid = 0x86;
 
     public WriteProtectRecord()

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/aggregates/SharedValueManager.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/aggregates/SharedValueManager.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.record.aggregates;
 
+import androidx.annotation.Keep;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -145,6 +147,7 @@ public final class SharedValueManager {
 
 	/**
 	 */
+	@Keep
 	public static SharedValueManager create(SharedFormulaRecord[] sharedFormulaRecords,
 			CellReference[] firstCells, ArrayRecord[] arrayRecords, TableRecord[] tableRecords) {
 		if (sharedFormulaRecords.length + firstCells.length + arrayRecords.length + tableRecords.length < 1) {

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/crypto/Biff8EncryptionKey.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/record/crypto/Biff8EncryptionKey.java
@@ -16,6 +16,8 @@
 ==================================================================== */
 package com.cherry.lib.doc.office.fc.hssf.record.crypto;
 
+import androidx.annotation.Keep;
+
 import java.io.ByteArrayOutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -38,9 +40,11 @@ public final class Biff8EncryptionKey {
 	 * Create using the default password and a specified docId
 	 * @param docId 16 bytes
 	 */
+	@Keep
 	public static Biff8EncryptionKey create(byte[] docId) {
 		return new Biff8EncryptionKey(createKeyDigest("VelvetSweatshop", docId));
 	}
+	@Keep
 	public static Biff8EncryptionKey create(String password, byte[] docIdData) {
 		return new Biff8EncryptionKey(createKeyDigest(password, docIdData));
 	}

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/usermodel/FontDetails.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/usermodel/FontDetails.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.usermodel;
 
+import androidx.annotation.Keep;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -100,6 +102,7 @@ public class FontDetails
      *                          particular font.
      * @return  a new FontDetails instance.
      */
+    @Keep
     public static FontDetails create( String fontName, Properties fontMetricsProps )
     {
         String heightStr = fontMetricsProps.getProperty( buildFontHeightProperty(fontName) );

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/usermodel/HSSFEvaluationWorkbook.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/usermodel/HSSFEvaluationWorkbook.java
@@ -18,6 +18,8 @@
 package com.cherry.lib.doc.office.fc.hssf.usermodel;
 
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hssf.formula.EvaluationCell;
 import com.cherry.lib.doc.office.fc.hssf.formula.EvaluationName;
 import com.cherry.lib.doc.office.fc.hssf.formula.EvaluationSheet;
@@ -50,6 +52,7 @@ public final class HSSFEvaluationWorkbook implements FormulaRenderingWorkbook, E
 	private final AWorkbook _uBook;
 	private final InternalWorkbook _iBook;
 
+	@Keep
 	public static HSSFEvaluationWorkbook create(AWorkbook book) {
 		if (book == null) {
 			return null;

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/usermodel/HSSFFormulaEvaluator.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/usermodel/HSSFFormulaEvaluator.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.usermodel;
 
+import androidx.annotation.Keep;
+
 import com.cherry.lib.doc.office.fc.hssf.formula.CollaboratingWorkbooksEnvironment;
 import com.cherry.lib.doc.office.fc.hssf.formula.IStabilityClassifier;
 import com.cherry.lib.doc.office.fc.hssf.formula.WorkbookEvaluator;
@@ -96,6 +98,7 @@ public class HSSFFormulaEvaluator implements FormulaEvaluator
      * evaluation begins.
      * @param udfFinder pass <code>null</code> for default (AnalysisToolPak only)
      */
+    @Keep
     public static HSSFFormulaEvaluator create(AWorkbook workbook,
         IStabilityClassifier stabilityClassifier, UDFFinder udfFinder)
     {

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/usermodel/HSSFWorkbook.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/hssf/usermodel/HSSFWorkbook.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.hssf.usermodel;
 
+import androidx.annotation.Keep;
+
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -170,6 +172,7 @@ public final class HSSFWorkbook extends POIDocument implements com.cherry.lib.do
     // SS中配色方案
     private HSSFPalette palette;
 
+    @Keep
     public static HSSFWorkbook create(InternalWorkbook book)
     {
         return new HSSFWorkbook(book);

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/ppt/PPTXReader.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/ppt/PPTXReader.java
@@ -900,7 +900,7 @@ public class PPTXReader extends AbstractReader
     
     /**
      * set slide page size
-     * @param model
+     * @param slideSize
      */
     public void setPageSize(Element slideSize)
     {

--- a/library/src/main/java/com/cherry/lib/doc/office/fc/ss/util/SSCellRange.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/fc/ss/util/SSCellRange.java
@@ -17,6 +17,8 @@
 
 package com.cherry.lib.doc.office.fc.ss.util;
 
+import androidx.annotation.Keep;
+
 import java.lang.reflect.Array;
 import java.util.Iterator;
 import java.util.List;
@@ -50,6 +52,7 @@ public final class SSCellRange<K extends ICell> implements CellRange<K> {
 		_flattenedArray = flattenedArray;
 	}
 
+	@Keep
 	public static <B extends ICell> SSCellRange<B> create(int firstRow, int firstColumn, int height, int width, List<B> flattenedList, Class<B> cellClass) {
 		int nItems = flattenedList.size();
 		if (height * width != nItems) {

--- a/library/src/main/java/com/cherry/lib/doc/office/pg/control/PGPageListItem.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/pg/control/PGPageListItem.java
@@ -203,28 +203,21 @@ public class PGPageListItem extends APageListItem
      * @see com.cherry.lib.doc.office.system.beans.pagelist.APageListItem#onLayout(boolean, int, int, int, int)
      *
      */
-    protected void onLayout(boolean changed, int left, int top, int right, int bottom)
-    {
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
         super.onLayout(changed, left, top, right, bottom);
         int w = right - left;
         int h = bottom - top;
-        if (mBusyIndicator != null)
-        {
+        if (mBusyIndicator != null) {
             int x, y;
-            if (w > listView.getWidth())
-            {
+            if (w > listView.getWidth()) {
                 x = (listView.getWidth() - BUSY_SIZE) / 2 - left;
-            }
-            else
-            {
+            } else {
                 x = (w - BUSY_SIZE) / 2;
             }
             if (h > listView.getHeight())
             {
                 y = (listView.getHeight() - BUSY_SIZE) / 2 - top;
-            }
-            else
-            {
+            } else {
                 y = (h - BUSY_SIZE) / 2;
             }
             mBusyIndicator.layout(x, y, x + BUSY_SIZE, y + BUSY_SIZE);

--- a/library/src/main/java/com/cherry/lib/doc/office/pg/control/PGPrintMode.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/pg/control/PGPrintMode.java
@@ -317,19 +317,15 @@ public class PGPrintMode extends FrameLayout implements IPageListViewListener
         Rect rect = getPageSize(position);
         return new PGPageListItem(listView, control, editor, rect.width(), rect.height());
     }
-    
+
     /**
-     * 
+     *
      */
-    public Rect getPageSize(int pageIndex)
-    {
+    public Rect getPageSize(int pageIndex) {
         Dimension d = pgModel.getPageSize();
-        if (d == null)
-        {
+        if (d == null) {
             pageSize.set(0, 0, getWidth(), getHeight());
-        }
-        else
-        {   
+        } else {
             pageSize.set(0, 0, d.width, d.height);
         }
         return pageSize;

--- a/library/src/main/java/com/cherry/lib/doc/office/pg/control/Presentation.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/pg/control/Presentation.java
@@ -106,22 +106,19 @@ public class Presentation extends FrameLayout implements IFind, IExportListener 
      *
      */
     public void initSlidebar() {
-        /*if (layoutParams == null)
-        {
-            return;
-        }
-        // 非指定高度才需要重高度
-        if (layoutParams.height == LayoutParams.MATCH_PARENT
-            || layoutParams.height == LayoutParams.FILL_PARENT)
-        {
-            mHeight = ((View)getParent()).getHeight() - getTop();
-            int bHeight = control.getMainFrame().getBottomBarHeight();
-            if (bHeight > 0 || isSlideShow())
-            {
-                mHeight -= bHeight;
-                setLayoutParams(new LinearLayout.LayoutParams(layoutParams.width, mHeight));
-            }
-        }*/
+        // FrameLayout.LayoutParams layoutParams = (FrameLayout.LayoutParams) getLayoutParams();
+        // if (layoutParams == null) {
+        //     return;
+        // }
+        // // 非指定高度才需要重高度
+        // if (layoutParams.height == LayoutParams.MATCH_PARENT) {
+        //     mHeight = ((View) getParent()).getHeight() - getTop();
+        //     int bHeight = control.getMainFrame().getBottomBarHeight();
+        //     if (bHeight > 0 || isSlideShow()) {
+        //         mHeight -= bHeight;
+        //         setLayoutParams(new FrameLayout.LayoutParams(layoutParams.width, mHeight));
+        //     }
+        // }
     }
 
     /**
@@ -334,12 +331,10 @@ public class Presentation extends FrameLayout implements IFind, IExportListener 
      * @return bitmap raw data
      */
     public Bitmap slideAreaToImage(int slideNumber, int srcLeft, int srcTop, int srcWidth, int srcHeight, int desWidth, int desHeight) {
-        if (slideNumber <= 0 || slideNumber > getRealSlideCount()
-                || !SysKit.isValidateRect((int) (getPageSize().getWidth()), (int) (getPageSize().getHeight()), srcLeft, srcTop, srcWidth, srcHeight)) {
+        if (slideNumber <= 0 || slideNumber > getRealSlideCount() || !SysKit.isValidateRect((int) (getPageSize().getWidth()), (int) (getPageSize().getHeight()), srcLeft, srcTop, srcWidth, srcHeight)) {
             return null;
         }
-        return SlideDrawKit.instance().slideAreaToImage(pgModel, editor, pgModel.getSlide(slideNumber - 1),
-                srcLeft, srcTop, srcWidth, srcHeight, desWidth, desHeight);
+        return SlideDrawKit.instance().slideAreaToImage(pgModel, editor, pgModel.getSlide(slideNumber - 1), srcLeft, srcTop, srcWidth, srcHeight, desWidth, desHeight);
     }
 
     /**
@@ -450,8 +445,7 @@ public class Presentation extends FrameLayout implements IFind, IExportListener 
     public float getFitZoom() {
         if (slideshow) {
             Dimension pageSize = getPageSize();
-            return Math.min((float) (mWidth) / pageSize.width,
-                    (float) (mHeight) / pageSize.height);
+            return Math.min((float) (mWidth) / pageSize.width, (float) (mHeight) / pageSize.height);
         }
         return pgPrintMode.getFitZoom();
     }
@@ -787,9 +781,8 @@ public class Presentation extends FrameLayout implements IFind, IExportListener 
      */
     public boolean hasPreviousAction_Slideshow() {
         synchronized (this) {
-            if (slideshow &&
-                    (slideIndex_SlideShow >= 1            //has previous slide
-                            || !slideView.gotopreviousSlide()))  //has previous action
+            if (slideshow && (slideIndex_SlideShow >= 1            //has previous slide
+                    || !slideView.gotopreviousSlide()))  //has previous action
             {
                 return true;
             }
@@ -802,8 +795,7 @@ public class Presentation extends FrameLayout implements IFind, IExportListener 
      */
     public void slideShow(byte type) {
         synchronized (this) {
-            if (!slideshow || !slideView.animationStoped()
-                    || control.getSysKit().getCalloutManager().getDrawingMode() != MainConstant.DRAWMODE_NORMAL) {
+            if (!slideshow || !slideView.animationStoped() || control.getSysKit().getCalloutManager().getDrawingMode() != MainConstant.DRAWMODE_NORMAL) {
                 return;
             }
             if (type == ISlideShow.SlideShow_PreviousSlide && hasPreviousSlide_Slideshow()) {

--- a/library/src/main/java/com/cherry/lib/doc/office/system/MainControl.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/system/MainControl.java
@@ -140,7 +140,9 @@ public class MainControl extends AbstractControl {
      */
     public void dismissProgressDialog() {
         if (progressDialog != null) {
-            progressDialog.dismiss();
+            if(progressDialog.getWindow() != null){
+                progressDialog.dismiss();
+            }
             progressDialog = null;
         }
         if (handler != null) {

--- a/library/src/main/java/com/cherry/lib/doc/office/system/beans/pagelist/APageListAdapter.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/system/beans/pagelist/APageListAdapter.java
@@ -87,15 +87,12 @@ public class APageListAdapter extends BaseAdapter
      * @param parent The parent that this view will eventually be attached to
      * @return A View corresponding to the data at the specified position.
      */
-    public View getView(int position, View convertView, ViewGroup parent)
-    {
-        APageListItem pageItem = (APageListItem)convertView;
+    public View getView(int position, View convertView, ViewGroup parent) {
+        APageListItem pageItem = (APageListItem) convertView;
         Rect pageSize = listView.getPageListViewListener().getPageSize(position);
-        if (convertView == null)
-        {
+        if (convertView == null) {
             pageItem = listView.getPageListItem(position, convertView, parent);
-            if (pageItem == null)
-            {
+            if (pageItem == null) {
                 pageSize.right = 794;
                 pageSize.bottom = 1124;
                 pageItem = new APageListItem(listView, pageSize.width(), pageSize.height());

--- a/library/src/main/java/com/cherry/lib/doc/office/wp/view/LayoutKit.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/wp/view/LayoutKit.java
@@ -6,8 +6,10 @@
  */
 package com.cherry.lib.doc.office.wp.view;
 
+import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.util.DisplayMetrics;
+import android.util.Log;
 
 import com.cherry.lib.doc.office.constant.MainConstant;
 import com.cherry.lib.doc.office.constant.wp.AttrIDConstant;
@@ -41,6 +43,7 @@ import com.cherry.lib.doc.office.wp.control.Word;
  * <p>
  */
 public class LayoutKit {
+    private static final String TAG = "LayoutKit";
     private int screenWidthPixels = 0;
     private int screenHeightPixels = 0;
     private static LayoutKit kit = new LayoutKit();
@@ -67,13 +70,22 @@ public class LayoutKit {
         }
         Word word = (Word) root.getContainer();
         if (word.getContext() != null && (screenWidthPixels == 0 || screenHeightPixels == 0)) {
-            //获取资源对象
+            // 获取资源对象
             Resources resources = word.getContext().getResources();
-            //获取屏幕数据
+            boolean isLandscape = resources.getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE;
+            // 获取屏幕数据
             DisplayMetrics displayMetrics = resources.getDisplayMetrics();
-            //获取屏幕宽高，单位是像素
-            screenWidthPixels = displayMetrics.widthPixels;
-            screenHeightPixels = displayMetrics.heightPixels;
+            // 获取屏幕宽高，单位是像素
+            int width = displayMetrics.widthPixels;
+            int height = displayMetrics.heightPixels;
+            if (isLandscape) {
+                screenWidthPixels = Math.max(width, height);
+                screenHeightPixels = Math.min(width, height);
+            } else {
+                screenWidthPixels = Math.min(width, height);
+                screenHeightPixels = Math.max(width, height);
+            }
+            Log.d(TAG, "layoutAllPage screenWidthPixels = " + screenWidthPixels + "; isLandscape " + isLandscape);
         }
         int dx = WPViewConstant.PAGE_SPACE;
         int dy = WPViewConstant.PAGE_SPACE;

--- a/library/src/main/java/com/cherry/lib/doc/office/wp/view/LayoutKit.java
+++ b/library/src/main/java/com/cherry/lib/doc/office/wp/view/LayoutKit.java
@@ -85,19 +85,22 @@ public class LayoutKit {
                 screenWidthPixels = Math.min(width, height);
                 screenHeightPixels = Math.max(width, height);
             }
-            Log.d(TAG, "layoutAllPage screenWidthPixels = " + screenWidthPixels + "; isLandscape " + isLandscape);
+
+            IView pv = root.getChildView();
+            int pvWidth = pv.getWidth();
+            float scale = 1;
+            if (screenWidthPixels != 0 && pvWidth != 0) {
+                scale = screenWidthPixels * 1f / pvWidth;
+                if (zoom == 1f) {
+                    word.setZoom(scale, 0, 0);
+                }
+            }
+            Log.d(TAG, "layoutAllPage screenWidthPixels = " + screenWidthPixels + "; isLandscape " + isLandscape + ", pvWidth = " + pvWidth + "; scale = " + scale);
         }
         int dx = WPViewConstant.PAGE_SPACE;
         int dy = WPViewConstant.PAGE_SPACE;
         IView pv = root.getChildView();
         int width = pv.getWidth();
-        float scale = 1;
-        if (screenWidthPixels != 0 && width != 0) {
-            scale = screenWidthPixels * 1f / width;
-            if (zoom == 1f) {
-                word.setZoom(scale, 0, 0);
-            }
-        }
         // int visibleWidth = word.getWidth();
         // visibleWidth = visibleWidth == 0 ? word.getWordWidth() : visibleWidth;
         // if (visibleWidth > width * zoom) {
@@ -127,10 +130,9 @@ public class LayoutKit {
      * @param flag        布局标记
      * @return
      */
-    public int layoutPara(IControl control, IDocument doc, DocAttr docAttr, PageAttr pageAttr, ParaAttr paraAttr,
-                          ParagraphView para, long startOffset, int x, int y, int w, int h, int flag) {
+    public int layoutPara(IControl control, IDocument doc, DocAttr docAttr, PageAttr pageAttr, ParaAttr paraAttr, ParagraphView para, long startOffset, int x, int y, int w, int h, int flag) {
         // get paragraph token
-        //ParaToken token = TokenManage.instance().allocToken(para);
+        // ParaToken token = TokenManage.instance().allocToken(para);
         int breakType = WPViewConstant.BREAK_NO;
         int dx = paraAttr.leftIndent;
         int dy = 0;
@@ -183,9 +185,7 @@ public class LayoutKit {
             }
             int lineIndent = getLineIndent(control, bnViewWidth, paraAttr, firstLine);
             if (bnView != null && lineIndent + paraAttr.leftIndent == paraAttr.tabClearPosition) {
-                if ((AttrManage.instance().hasAttribute(elem.getAttribute(), AttrIDConstant.PARA_SPECIALINDENT_ID)
-                        && AttrManage.instance().getParaSpecialIndent(elem.getAttribute()) < 0)
-                        || AttrManage.instance().hasAttribute(elem.getAttribute(), AttrIDConstant.PARA_INDENT_LEFT_ID)) {
+                if ((AttrManage.instance().hasAttribute(elem.getAttribute(), AttrIDConstant.PARA_SPECIALINDENT_ID) && AttrManage.instance().getParaSpecialIndent(elem.getAttribute()) < 0) || AttrManage.instance().hasAttribute(elem.getAttribute(), AttrIDConstant.PARA_INDENT_LEFT_ID)) {
                     bnView.setX(0);
                     lineIndent = bnViewWidth;
                     dx = 0;
@@ -196,9 +196,7 @@ public class LayoutKit {
             breakType = layoutLine(control, doc, docAttr, pageAttr, paraAttr, line, bnView, dx, dy, spanW - lineIndent, spanH, elemEnd, flag);
             int lineHeight = line.getLayoutSpan(WPViewConstant.Y_AXIS);
             if (!ss && !keepOne
-                    /*&& breakType == WPViewConstant.BREAK_LIMIT*/
-                    && ((spanH - lineHeight < 0 || line.getChildView() == null)
-                    || spanW - lineIndent <= 0)) {
+                    /*&& breakType == WPViewConstant.BREAK_LIMIT*/ && ((spanH - lineHeight < 0 || line.getChildView() == null) || spanW - lineIndent <= 0)) {
                 breakType = WPViewConstant.BREAK_LIMIT;
                 para.deleteView(line, true);
                 break;
@@ -214,14 +212,14 @@ public class LayoutKit {
                 para.appendChlidView(line);
             }
             keepOne = false;
-            //flag = ViewKit.instance().setBitValue(flag, WPViewConstant.LAYOUT_FLAG_KEEPONE, keepOne);
+            // flag = ViewKit.instance().setBitValue(flag, WPViewConstant.LAYOUT_FLAG_KEEPONE, keepOne);
             firstLine = false;
             bnView = null;
         }
         para.setSize(maxWidth, paraHeight);
         para.setEndOffset(lineStart);
         //
-        //token.setFree(true);
+        // token.setFree(true);
         return breakType;
     }
 
@@ -232,8 +230,8 @@ public class LayoutKit {
      */
     public int buildLine(IDocument doc, ParagraphView para) {
         int breakType = WPViewConstant.BREAK_NO;
-        //get paragraph token
-        //ParaToken token = TokenManage.instance().allocToken(para);
+        // get paragraph token
+        // ParaToken token = TokenManage.instance().allocToken(para);
         //
         /*AttrManage.instance().fillPageAttr(pageAttr, doc.getSection(0).getAttribute());
         //
@@ -318,8 +316,7 @@ public class LayoutKit {
      * @param flag     布局标记
      * @return
      */
-    public int layoutLine(IControl control, IDocument doc, DocAttr docAttr, PageAttr pageAttr, ParaAttr paraAttr, LineView line,
-                          BNView bnView, int x, int y, int w, int h, long maxEnd, int flag) {
+    public int layoutLine(IControl control, IDocument doc, DocAttr docAttr, PageAttr pageAttr, ParaAttr paraAttr, LineView line, BNView bnView, int x, int y, int w, int h, long maxEnd, int flag) {
         int breakType = WPViewConstant.BREAK_NO;
         int dx = 0;
         int dy = 0;
@@ -343,8 +340,7 @@ public class LayoutKit {
             leaf.setStartOffset(pos);
             leaf.setLocation(dx, dy);
             breakType = leaf.doLayout(docAttr, pageAttr, paraAttr, dx, dy, spanW, h, maxEnd, flag);
-            if ((leaf.getType() == WPViewConstant.OBJ_VIEW || leaf.getType() == WPViewConstant.SHAPE_VIEW)
-                    && breakType == WPViewConstant.BREAK_LIMIT) {
+            if ((leaf.getType() == WPViewConstant.OBJ_VIEW || leaf.getType() == WPViewConstant.SHAPE_VIEW) && breakType == WPViewConstant.BREAK_LIMIT) {
                 line.deleteView(leaf, true);
                 breakType = WPViewConstant.BREAK_NO;
                 break;
@@ -359,9 +355,7 @@ public class LayoutKit {
                 lineHeigthExceptShape = Math.max(lineHeigthExceptShape, leaf.getLayoutSpan(WPViewConstant.Y_AXIS));
             }
             spanW -= leafWidth;
-            if (breakType == WPViewConstant.BREAK_LIMIT
-                    || breakType == WPViewConstant.BREAK_ENTER
-                    || breakType == WPViewConstant.BREAK_PAGE) {
+            if (breakType == WPViewConstant.BREAK_LIMIT || breakType == WPViewConstant.BREAK_ENTER || breakType == WPViewConstant.BREAK_PAGE) {
                 break;
             }
             flag = ViewKit.instance().setBitValue(flag, WPViewConstant.LAYOUT_FLAG_KEEPONE, false);
@@ -395,10 +389,8 @@ public class LayoutKit {
      * @param flag
      * @return
      */
-    private BNView createBNView(IControl control, IDocument doc, DocAttr docAttr, PageAttr pageAttr, ParaAttr paraAttr,
-                                ParagraphView para, int x, int y, int w, int h, int flag) {
-        if (paraAttr.listID >= 0 && paraAttr.listLevel >= 0
-                || paraAttr.pgBulletID >= 0) {
+    private BNView createBNView(IControl control, IDocument doc, DocAttr docAttr, PageAttr pageAttr, ParaAttr paraAttr, ParagraphView para, int x, int y, int w, int h, int flag) {
+        if (paraAttr.listID >= 0 && paraAttr.listLevel >= 0 || paraAttr.pgBulletID >= 0) {
             BNView bnView = (BNView) ViewFactory.createView(control, null, null, WPViewConstant.BN_VIEW);
             bnView.doLayout(doc, docAttr, pageAttr, paraAttr, para, x, y, w, h, flag);
             para.setBNView(bnView);
@@ -461,9 +453,9 @@ public class LayoutKit {
         return 0;
     }
     //
-    //private DocAttr docAttr = new DocAttr();
+    // private DocAttr docAttr = new DocAttr();
     //
-    //private PageAttr pageAttr = new PageAttr();
+    // private PageAttr pageAttr = new PageAttr();
     //
-    //private ParaAttr paraAttr = new ParaAttr(); 
+    // private ParaAttr paraAttr = new ParaAttr();
 }


### PR DESCRIPTION
1. 修改dialog引起的崩溃
2. 修改上一个界面橫屏，文档预览界面竖屏显示时，word文档宽度还是横屏宽度的问题
3. 对反射用到的属性和方法增加keep标注，方式代码混淆引起的崩溃